### PR TITLE
Allow user to toggle server connection with .env file

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -7,11 +7,11 @@ module.exports = {
   development: {
     client: "postgresql",
     connection: {
-      host: "127.0.0.1",
-      port: 5432,
-      database: "kojin",
-      user: "postgres",
-      password: "",
+      host: process.env.PG_HOST || "127.0.0.1",
+      port: process.env.PG_PORT || 5432,
+      database: process.env.PG_DATABASE || "kojin",
+      user: process.env.PG_USER || "postgres",
+      password: process.env.PG_PASSWORD || "",
     },
     pool: {
       min: 2,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "dev": "ENVIRONMENT=development nodemon server.js",
     "start": "nodemon server.js",
     "build": "npm install",
     "migrate": "knex migrate:latest",


### PR DESCRIPTION
This allows the user to deploy the server in development mode to whatever local database they want. They can do so by adding the file settings to their `.env` file, and changing it to match their local database.

```.env
# .env file
# environment can be run in development or production mode
ENVIRONMENT=development

PG_HOST=127.0.0.1
PG_PORT=5432
PG_DATABASE=kojin
PG_USER=postgres
PG_PASSWORD=
```