### PR TITLE
Create challenge table

### DIFF
--- a/knex/migrations/20240524005652_create_game_table.js
+++ b/knex/migrations/20240524005652_create_game_table.js
@@ -4,7 +4,7 @@
  */
 exports.up = function (knex) {
   return knex.schema.createTable("game", (table) => {
-    table.increments("id");
+    table.increments("id").unsigned().primary();
     table.string("title").notNullable();
     table.string("imagesrc").notNullable();
     table.integer("year", 4).notNullable();

--- a/knex/migrations/20240524005652_create_game_table.js
+++ b/knex/migrations/20240524005652_create_game_table.js
@@ -4,7 +4,7 @@
  */
 exports.up = function (knex) {
   return knex.schema.createTable("game", (table) => {
-    table.increments("id").unsigned().primary();
+    table.increments("game_id").unsigned().primary();
     table.string("title").notNullable();
     table.string("imagesrc").notNullable();
     table.integer("year", 4).notNullable();

--- a/knex/migrations/20240617045908_create_challenge_table.js
+++ b/knex/migrations/20240617045908_create_challenge_table.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("challenge", (table) => {
+    table.increments("id").unsigned().primary();
+    table.date("challenge_date").unique().notNullable();
+    table.integer("challenge_game_id").references("id").inTable("game");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("challenge");
+};

--- a/knex/migrations/20240617045908_create_challenge_table.js
+++ b/knex/migrations/20240617045908_create_challenge_table.js
@@ -4,9 +4,9 @@
  */
 exports.up = function (knex) {
   return knex.schema.createTable("challenge", (table) => {
-    table.increments("id").unsigned().primary();
+    table.increments("challenge_id").unsigned().primary();
     table.date("challenge_date").unique().notNullable();
-    table.integer("challenge_game_id").references("id").inTable("game");
+    table.integer("challenge_game_id").references("game_id").inTable("game");
   });
 };
 

--- a/knex/seeds/01_games.js
+++ b/knex/seeds/01_games.js
@@ -1,4 +1,5 @@
 exports.seed = async function (knex) {
+  // remove challenges first to prevent foreign key errors
   await knex("challenge").del();
   await knex("game").del();
 

--- a/knex/seeds/01_games.js
+++ b/knex/seeds/01_games.js
@@ -1,5 +1,6 @@
 exports.seed = async function (knex) {
-  await knex("game").del;
+  await knex("challenge").del();
+  await knex("game").del();
 
   await knex("game").insert([
     {

--- a/knex/seeds/02_challenges.js
+++ b/knex/seeds/02_challenges.js
@@ -1,36 +1,20 @@
+const { subDays, format } = require("date-fns");
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
 exports.seed = async function (knex) {
-  await knex("challenge").insert([
-    {
-      challenge_date: "2024-06-16",
+  const challengeEntries = [];
+  for (let i = 0; i < 30; ++i) {
+    challengeEntries.push({
+      challenge_date: format(subDays(Date.now(), i), "yyyy-MM-dd"),
       challenge_game_id: knex("game")
         .select("id")
         .orderByRaw("random()")
         .limit(1),
-    },
-    {
-      challenge_date: "2024-06-17",
-      challenge_game_id: knex("game")
-        .select("id")
-        .orderByRaw("random()")
-        .limit(1),
-    },
-    {
-      challenge_date: "2024-06-18",
-      challenge_game_id: knex("game")
-        .select("id")
-        .orderByRaw("random()")
-        .limit(1),
-    },
-    {
-      challenge_date: "2024-06-19",
-      challenge_game_id: knex("game")
-        .select("id")
-        .orderByRaw("random()")
-        .limit(1),
-    },
-  ]);
+    });
+  }
+
+  await knex("challenge").insert(challengeEntries);
 };

--- a/knex/seeds/02_challenges.js
+++ b/knex/seeds/02_challenges.js
@@ -1,0 +1,36 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.seed = async function (knex) {
+  await knex("challenge").insert([
+    {
+      challenge_date: "2024-06-16",
+      challenge_game_id: knex("game")
+        .select("id")
+        .orderByRaw("random()")
+        .limit(1),
+    },
+    {
+      challenge_date: "2024-06-17",
+      challenge_game_id: knex("game")
+        .select("id")
+        .orderByRaw("random()")
+        .limit(1),
+    },
+    {
+      challenge_date: "2024-06-18",
+      challenge_game_id: knex("game")
+        .select("id")
+        .orderByRaw("random()")
+        .limit(1),
+    },
+    {
+      challenge_date: "2024-06-19",
+      challenge_game_id: knex("game")
+        .select("id")
+        .orderByRaw("random()")
+        .limit(1),
+    },
+  ]);
+};

--- a/knex/seeds/02_challenges.js
+++ b/knex/seeds/02_challenges.js
@@ -10,7 +10,7 @@ exports.seed = async function (knex) {
     challengeEntries.push({
       challenge_date: format(subDays(Date.now(), i), "yyyy-MM-dd"),
       challenge_game_id: knex("game")
-        .select("id")
+        .select("game_id")
         .orderByRaw("random()")
         .limit(1),
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
+        "date-fns": "^3.6.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "knex": "^3.1.0",
@@ -227,6 +228,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -1562,6 +1572,11 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/KojinKuro/ludole-api#readme",
   "dependencies": {
     "cors": "^2.8.5",
+    "date-fns": "^3.6.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "knex": "^3.1.0",

--- a/server.js
+++ b/server.js
@@ -75,11 +75,11 @@ app.get("/api/v1/challenge/:date", async (req, res) => {
       return res.status(400).json({ message: "This is in the future" });
     }
 
-    const game = await knex("game")
+    let challengeGame = await knex("game")
       .select("*")
       .join("challenge", "challenge.challenge_game_id", "=", "game.game_id")
       .where("challenge_date", challengeDate);
-    if (game.length) return res.json(game[0]);
+    if (challengeGame.length) return res.json(challengeGame[0]);
 
     // generate challenge
     await knex("challenge").insert({
@@ -90,11 +90,11 @@ app.get("/api/v1/challenge/:date", async (req, res) => {
         .limit(1),
     });
 
-    const generatedGame = await knex("game")
+    challengeGame = await knex("game")
       .select("*")
       .join("challenge", "challenge.challenge_game_id", "=", "game.game_id")
       .where("challenge_date", challengeDate);
-    if (game.length) return res.json(generatedGame[0]);
+    if (challengeGame.length) return res.json(challengeGame[0]);
     else return res.status(500).json({ message: "Something bad happened" });
   } catch (err) {
     res.status(500).json({ message: "Some error occurred fetching challenge" });

--- a/utils/generate.js
+++ b/utils/generate.js
@@ -1,9 +1,0 @@
-import { createHash } from "crypto";
-
-// NOTE: this code can only be run in the server because crypto is a Node.js module.
-
-// can generate number between 0 to UPPER_RANGE - 1
-export function generateNumberFromSeed(KEY, UPPER_RANGE) {
-  const HASH = createHash("sha1").update(String(KEY)).digest().readUInt32BE();
-  return HASH % UPPER_RANGE;
-}

--- a/utils/generate.js
+++ b/utils/generate.js
@@ -1,0 +1,9 @@
+import { createHash } from "crypto";
+
+// NOTE: this code can only be run in the server because crypto is a Node.js module.
+
+// can generate number between 0 to UPPER_RANGE - 1
+export function generateNumberFromSeed(KEY, UPPER_RANGE) {
+  const HASH = createHash("sha1").update(String(KEY)).digest().readUInt32BE();
+  return HASH % UPPER_RANGE;
+}


### PR DESCRIPTION
# Overview

Will migrate and seed the `challenge` table. Create an endpoint to access the `challenge` table.

## Context

The `challenge` table is responsible for keeping track of what game is the correct answer for a given day. If there is no challenge for a given day and it is: a valid day, and in the past, it will generate an appropriate challenge for that day.

The API endpoint to access it is: `api/v1/challenge/YYYY-MM-DD` where you replace YYYY with a year, MM with a month, and DD with a day. For example to access the date for July 5th, 2024 is `api/v1/challenge/2024-06-05`

The `challenge` table will be seeded for the last 30 days from when the seeding begins.